### PR TITLE
Added space between get started and contact us button in mobile version

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,7 +44,7 @@
          <h2 style="font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;"><span>India’s </span>largest online verification network</h2> 
           <div>
             <a href="#why-us" class="btn-get-started scrollto">Get Started</a>
-            <a href="#footer" class="btn-get-started scrollto">Contact Us</a>
+            <a href="#footer" class="btn-get-started scrollto" style="margin-top: 5px;">Contact Us</a>
           </div>
         </div>
 


### PR DESCRIPTION
## Related Issue 

Get started and Contact us button had no space between them in the mobile version

Closes: #[issue 31]

### Describe the changes you've made

Using css I add margin  above the contact us button

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Mention any unusual behaviour of your code (Write NA if not)
Any unusual behaviour of your code

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly whereever it was hard to understand.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Info (optional)
Any additional information you want to give