### PR TITLE
Certificate PDF Conversion without API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ marshmallow==3.10.0
 mysqlclient==2.0.3
 oauthlib==3.1.0
 passlib==1.7.4
+pdfkit==0.6.1
 Pillow==8.1.2
 pycodestyle==2.7.0
 python-dateutil==2.8.1

--- a/templates/certificate.html
+++ b/templates/certificate.html
@@ -92,14 +92,20 @@
                 </div>
                 <div class="col-xs-4 pm-certified col-xs-4 text-center">
                   <span class="pm-credits-text block sans">Certified at</span>
-                  <span class="pm-empty-space block underline">{{ postc.dateupdate}}</span>
+                  <span class="pm-empty-space block underline">{{ postc.last_update}}</span>
                   <span class="bold block"></span>
                   <span class="bold block">Certificate No. # {{ postc.number}}</span>
                 </div>
+                
                 {% set qr_image = 'qr_codes/' + qr_code %}
-                  <center><img src="{{ url_for('static',filename=qr_image)}}" alt="QR Code" style="width: 100px; height:100px;"></center>
-                <center><form style="{{ style }}" action="http://api.pdflayer.com/api/convert?access_key={{ json["pdfapi"] }}&document_url=https://{{ json["site_url"] }}/certifyd/{{ postc.number }}&page_size=A4&margin_top=&margin_bottom=&margin_left=&margin_right=" method="post"></form>
-  <button type="submit" class="btn btn-success"><span class="glyphicon glyphicon-download-alt" onclick="window.print();></span> Download Certificate</button>
+                {% if pdf %}
+                  <center><img src="{{base_url}}{{ url_for('static',filename=qr_image)}}" alt="QR Code" style="width: 100px; height:100px;"></center>
+                {% else %}
+                
+                <center><img src="{{ url_for('static',filename=qr_image)}}" alt="QR Code" style="width: 100px; height:100px;"></center>
+                {% endif %}
+                  <center>
+  <a href="/download/{{number}}.pdf"><button type="submit" class="btn btn-success"><span class="glyphicon glyphicon-download-alt"></span> Download Certificate</button></a>
                 </form></center>
                 <!-- AddToAny BEGIN -->
 <br><div style="{{ style }}"><center>


### PR DESCRIPTION
## Related Issue 

- Info about the related issue 

Closes: #160 

### Describe the changes you've made

Give a clear description what modifications you have made
Instead of calling an API service to generate PDF, I've used wkhtmltopdf and pdfkit to generate PDF from HTML. Also, wherever the server is deployed, wkhtmltopdf needs to be installed there. The documentation for it is available [here](https://wkhtmltopdf.org/) . 

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code style update (formatting, local variables)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Mention any unusual behaviour of your code (Write NA if not)
Any unusual behaviour of your code
NA

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly whereever it was hard to understand.
- [] My changes generate no new warnings.
- [] Any dependent changes have been merged and published in downstream modules.

## Additional Info (optional)
Any additional information you want to give