### PR TITLE
Auto Label

### DIFF
--- a/.github/workflows/issue_label.yml
+++ b/.github/workflows/issue_label.yml
@@ -1,0 +1,13 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          labels-synonyms: '{"GSSOC21":["GSSOC","GSSOC21","gssoc","Gssoc","GSSoC","gssoc21"]}'


### PR DESCRIPTION
## Related Issue 

- The Auto Label script has been added and now whenever someone requests to contribute under GSSOC the label will be added automatically by gitbot.

Closes: #174 

### Describe the changes you've made

I have added a script in .github/workflows folder for the bot to function automatically.

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code style update (formatting, local variables)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Mention any unusual behavior of your code (Write NA if not)
Any unusual behavior of your code

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional Info (optional)
I hope this feature helps! :)