### PR TITLE
Revert "Bump pycodestyle from 2.8.0 to 2.9.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ passlib==1.7.4
 pdfkit==1.0.0
 Pillow==9.0.1
 psycopg2==2.9.1
-pycodestyle==2.9.1
+pycodestyle==2.8.0
 python-dateutil==2.8.2
 python-decouple==3.6
 python-dotenv==0.20.0


### PR DESCRIPTION
Reverts vigneshshettyin/Flask-Generate-Certificate#743